### PR TITLE
Guard against parallel requests.

### DIFF
--- a/MMM-PrometheusAlerts.js
+++ b/MMM-PrometheusAlerts.js
@@ -31,7 +31,7 @@ Module.register("MMM-PrometheusAlerts", {
 
 	scheduleUpdate: function (delay) {
 		var self = this;
-		if(self.isScheduled) {
+		if (self.isScheduled) {
 			return;
 		}
 		var nextLoad = this.config.updateInterval;

--- a/MMM-PrometheusAlerts.js
+++ b/MMM-PrometheusAlerts.js
@@ -30,14 +30,19 @@ Module.register("MMM-PrometheusAlerts", {
 	},
 
 	scheduleUpdate: function (delay) {
+		var self = this;
+		if(self.isScheduled) {
+			return;
+		}
 		var nextLoad = this.config.updateInterval;
 		if (typeof delay !== "undefined" && delay !== null && delay >= 0) {
 			nextLoad = delay;
 		}
 
-		var self = this;
+		self.isScheduled = true;
 		setTimeout(function () {
 			Log.info("MMM-PrometheusAlerts - Requesting status update");
+			self.isScheduled = false;
 			self.sendSocketNotification("GET_PROMTHEUS_ALERTS", { prometheusUrl: self.config.prometheusUrl });
 		}, nextLoad);
 	},

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ Add the module to the modules array in the `config/config.js` file:
 
 ## Config Options
 
-| **Option**           | **Default**     | **Description**                                                               |
-| -------------------- | --------------- | ----------------------------------------------------------------------------- |
-| `prometheusUrl`      | ''              | The URL of the Prometheus Instance.                                           |
-| `animationSpeed`     | 3000            | **Optional** The speed of the show and hide animations in milliseconds        |
-| `useHeader`          | `true`          | **Optional** Whether or not to show the header                                |
-| `maxWidth`           | `300px`         | **Optional** The maximum width for this module                                |
-| `initialLoadDelay`   | `3250`          | **Optional** How long to wait, in milliseconds, before the first status check |
-| `updateInterval`     | `2 * 60 * 1000` | **Optional** How often to check the status (defaults to 2 minutes)            |
+| **Option**         | **Default**     | **Description**                                                               |
+| ------------------ | --------------- | ----------------------------------------------------------------------------- |
+| `prometheusUrl`    | ''              | The URL of the Prometheus Instance.                                           |
+| `animationSpeed`   | 3000            | **Optional** The speed of the show and hide animations in milliseconds        |
+| `useHeader`        | `true`          | **Optional** Whether or not to show the header                                |
+| `maxWidth`         | `300px`         | **Optional** The maximum width for this module                                |
+| `initialLoadDelay` | `3250`          | **Optional** How long to wait, in milliseconds, before the first status check |
+| `updateInterval`   | `2 * 60 * 1000` | **Optional** How often to check the status (defaults to 2 minutes)            |
 
 ## Config Examples
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -35,7 +35,7 @@ module.exports = NodeHelper.create({
 
 	getPrometheusAlerts: function (prometheusUrl) {
 		let self = this;
-		if(self.pending) {
+		if (self.pending) {
 			return;
 		}
 		self.pending = true;

--- a/node_helper.js
+++ b/node_helper.js
@@ -35,6 +35,10 @@ module.exports = NodeHelper.create({
 
 	getPrometheusAlerts: function (prometheusUrl) {
 		let self = this;
+		if(self.pending) {
+			return;
+		}
+		self.pending = true;
 		var url = prometheusUrl + "/api/v1/alerts";
 		fetch(url, {
 			method: "get"
@@ -67,6 +71,9 @@ module.exports = NodeHelper.create({
 			.catch((error) => {
 				self.logError(error);
 				self.sendSocketNotification("PROMTHEUSALERT_RETRIEVE_ERROR");
+			})
+			.finally(() => {
+				self.pending = false;
 			});
 	},
 


### PR DESCRIPTION
I ran into a corner case where my instance started making a ton of parallel requests to the Prometheus server locking everything up.  From a review of the code I'm not sure how this could occur but I've added some primitives to ensure only one timeout is scheduled at any given time and only one HTTP request is being made to the Prometheus server.